### PR TITLE
fixed `withoutTarget`

### DIFF
--- a/repository/structure_number_of_alpha_helices_pdb.md
+++ b/repository/structure_number_of_alpha_helices_pdb.md
@@ -1,4 +1,4 @@
-# PDBエントリをalpha_helixで分類(ヒトのみ)（井手, 守屋）
+# PDBエントリをalpha_helixで分類(ヒトのみ) (フロント開発用)（井手, 守屋）
 
 ## Description
 
@@ -117,8 +117,8 @@ WHERE{
   {
     SELECT DISTINCT ?PDBentry ?title 
     WHERE {
-      {{#if filter_list}}
-      VALUES ?PDBentry { {{#each filter_list}} pdbr:{{this}} {{/each}} }
+      {{#if queryArray}}
+      VALUES ?PDBentry { {{#each queryArray}} pdbr:{{this}} {{/each}} }
       {{/if}}
       ?PDBentry  a pdbo:datablock ;
                  dc:title ?title .

--- a/repository/structure_number_of_alpha_helices_pdb.md
+++ b/repository/structure_number_of_alpha_helices_pdb.md
@@ -1,4 +1,4 @@
-# PDBエントリをalpha_helixで分類(ヒトのみ) (フロント開発用)（井手, 守屋）
+# PDBエントリをalpha_helixで分類(ヒトのみ)（井手, 守屋）
 
 ## Description
 

--- a/repository/structure_number_of_beta_sheets_pdb.md
+++ b/repository/structure_number_of_beta_sheets_pdb.md
@@ -122,7 +122,7 @@ WHERE{
       {{/if}}
       ?PDBentry  a pdbo:datablock ;
                  dc:title ?title .
-      MINUS {?PDBentry pdbo:has_struct_confCategory ?sheet . }
+      MINUS {?PDBentry pdbo:has_struct_sheetCategory ?sheet . }
       {
         SELECT DISTINCT ?PDBentry {
           ?PDBentry pdbo:has_entityCategory

--- a/repository/structure_number_of_beta_sheets_pdb.md
+++ b/repository/structure_number_of_beta_sheets_pdb.md
@@ -1,4 +1,4 @@
-# PDBエントリをbeta_sheetで分類(ヒトのみ) (フロント開発用)（井手, 守屋）
+# PDBエントリをbeta_sheetで分類(ヒトのみ)（井手, 守屋）
 
 ## Description
 


### PR DESCRIPTION
`withoutTarget` を修正。
- beta sheet の数が 0 のものを取得するべきところで alpha helix が 0 を取得していたのを修正。
- alpha helices のほうの、変数名修正忘れ部分を修正。これにより、`queryIds` に何を入力しても数が 0 のものが帰ってきていた問題が解決。