### PR TITLE
updated SPARQLets for metastanza templates

### DIFF
--- a/repository/metastanza_chebi.md
+++ b/repository/metastanza_chebi.md
@@ -1,0 +1,68 @@
+# 化合物の詳細情報を出す（信定・山本・建石）
+
+## Parameters
+
+* `id`
+  * default: 15414
+  * example: 15414, 17232
+
+## Endpoint
+
+https://integbio.jp/togosite/sparql
+
+## `main`
+```sparql
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX oboinowl: <http://www.geneontology.org/formats/oboInOwl#>
+PREFIX iao: <http://purl.obolibrary.org/obo/IAO_>
+PREFIX chebi: <http://purl.obolibrary.org/obo/chebi/>
+
+SELECT DISTINCT ?chebi ?molecular_formula ?id
+                (GROUP_concat(distinct ?altid; separator = ", ") as ?altids)
+                (GROUP_concat(distinct ?label; separator = "__") as ?labels)
+                (GROUP_concat(distinct ?synonym; separator = "__") as ?synonyms)
+                ?mass ?smiles ?inchi ?definition
+FROM <http://rdf.integbio.jp/dataset/togosite/chebi>
+WHERE {
+  VALUES ?chebi  { obo:CHEBI_{{id}} }
+  ?chebi rdfs:label ?label ;
+         oboinowl:id ?id .
+  OPTIONAL { ?chebi oboinowl:hasExactSynonym ?synonym . }
+  OPTIONAL { ?chebi chebi:formula ?molecular_formula . }
+  OPTIONAL { ?chebi chebi:inchi ?inchi . }
+  OPTIONAL { ?chebi chebi:mass ?mass . }
+  OPTIONAL { ?chebi chebi:smiles ?smiles . }
+  OPTIONAL { ?chebi iao:0000115 ?definition . }
+  OPTIONAL { ?chebi oboinowl:hasAlternativeId ?altid . }
+}
+```
+
+## `return`
+
+```javascript
+({ main }) => {
+  const objs = [];
+  const data = main.results.bindings[0];
+  objs[0] = {
+    URL: data.chebi.value,
+    ID: data.id.value,
+    molecular_formula: data.molecular_formula?.value ?? "",
+    label: makeList(data.labels.value.split("__")),
+    synonym: "",
+    definition: data.definition?.value ?? "",
+    mass: data.mass?.value ?? "",
+    SMILES: data.smiles?.value ?? "",
+    InChI: data.inchi?.value ?? "",
+    secondary_ID: data.altids?.value ?? ""
+  };
+  if (data.synonyms?.value)
+    objs[0].synonym = makeList(data.synonyms.value.split("__"));
+  return objs;
+
+  function makeList(strs) {
+    return "<ul><li>" + strs.join("</li><li>") + "</li></ul>";
+  }
+};
+```

--- a/repository/metastanza_chembl_compound.md
+++ b/repository/metastanza_chembl_compound.md
@@ -1,0 +1,64 @@
+# 化合物の詳細情報を出す（信定・山本・建石）
+
+## Parameters
+
+* `id`
+  * default: CHEMBL6939
+  * example: CHEMBL6939, CHEMBL1201330
+
+## Endpoint
+
+https://integbio.jp/togosite/sparql
+
+## `main`
+```sparql
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX cco: <http://rdf.ebi.ac.uk/terms/chembl#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX chembl: <http://rdf.ebi.ac.uk/resource/chembl/molecule/>
+PREFIX cheminf: <http://semanticscience.org/resource/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+SELECT DISTINCT ?chembl ?id ?molecular_formula ?type
+                (GROUP_CONCAT(DISTINCT ucase(?label); separator = "__") as ?labels)
+                ?molecular_weight ?smiles ?inchi ?formula_img
+FROM <http://rdf.integbio.jp/dataset/togosite/chembl>
+WHERE {
+  VALUES ?chembl  { chembl:{{id}} }
+  ?chembl a cco:SmallMolecule ;
+          skos:altLabel ?label ;
+          cco:substanceType ?type ;
+          foaf:depiction  ?formula_img .
+  OPTIONAL { ?chembl cheminf:SIO_000008 ?att_1. ?att_1 a cheminf:CHEMINF_000042 ; cheminf:SIO_000300 ?molecular_formula }.
+  OPTIONAL { ?chembl cheminf:SIO_000008 ?att_2. ?att_2 a cheminf:CHEMINF_000216 ; cheminf:SIO_000300 ?molecular_weight  }.
+  OPTIONAL { ?chembl cheminf:SIO_000008 ?att_3. ?att_3 a cheminf:CHEMINF_000018 ; cheminf:SIO_000300 ?smiles  }.
+  OPTIONAL { ?chembl cheminf:SIO_000008 ?att_4. ?att_4 a cheminf:CHEMINF_000113 ; cheminf:SIO_000300 ?inchi }.
+  BIND (strafter(str(?chembl), str(chembl:)) AS ?id)
+}       
+```
+
+## `return`
+
+```javascript
+({ main }) => {
+  const objs = [];
+  const data = main.results.bindings[0];
+  objs[0] = {
+    URL: data.chembl.value,
+    ID: data.id.value,
+    molecular_formula: data.molecular_formula?.value ?? "",
+    type: data.type.value,
+    label: makeList(data.labels.value.split("__")),
+    molecular_weight: data.molecular_weight?.value ?? "",
+    SMILES: data.smiles?.value ?? "",
+    InChI: data.inchi?.value ?? "",
+    formula_img: data.formula_img.value
+  };
+  return objs;
+
+  function makeList(strs) {
+    return "<ul><li>" + strs.join("</li><li>") + "</li></ul>";
+  }
+};
+```

--- a/repository/metastanza_ensembl_gene.md
+++ b/repository/metastanza_ensembl_gene.md
@@ -1,0 +1,141 @@
+## Endpoint
+
+https://integbio.jp/togosite/sparql
+
+## Parameters
+
+* `id`
+  * default: ENSG00000150773
+  * example: ENSG00000150773
+
+## `main`
+
+```sparql
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX idt_ensg: <http://identifiers.org/ensembl/>
+PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX taxon: <http://identifiers.org/taxonomy/>
+PREFIX faldo: <http://biohackathon.org/resource/faldo#>
+PREFIX refexo: <http://purl.jp/bio/01/refexo#>
+PREFIX schema: <http://schema.org/>
+PREFIX ensg: <http://rdf.ebi.ac.uk/resource/ensembl/>
+
+SELECT DISTINCT ?ensg_id ?idt_ensg ?gene_symbol ?desc ?type_label ?location ?type_gtex ?type_hpa_cell ?type_hpa_tissue
+  (GROUP_CONCAT(DISTINCT ?gtex_tissue_label; separator=", ") AS ?gtex_tissue_labels)
+  (GROUP_CONCAT(DISTINCT ?hpa_tissue_label; separator=", ") AS ?hpa_tissue_labels)
+  (GROUP_CONCAT(DISTINCT ?hpa_cell_label; separator=", ") AS ?hpa_cell_labels)
+WHERE {
+  VALUES ?ensg { ensg:{{id}} }
+  VALUES ?idt_ensg { idt_ensg:{{id}} }
+  GRAPH <http://rdf.integbio.jp/dataset/togosite/ensembl> {
+    ?ensg obo:RO_0002162 taxon:9606 ;
+             dc:identifier ?ensg_id ;
+             rdfs:label ?gene_symbol ;
+             dc:description ?desc ;
+             faldo:location ?loc ;
+             a ?type .
+    FILTER(STRSTARTS(STR(?type), "http://rdf.ebi.ac.uk/terms/ensembl/"))
+    BIND(REPLACE(STRAFTER(STR(?type), "http://rdf.ebi.ac.uk/terms/ensembl/"), "_", " ") as ?type_label)
+    ?loc rdfs:label ?location .
+  }
+
+  OPTIONAL {
+    GRAPH <http://rdf.integbio.jp/dataset/togosite/refex_tissue_specific_genes_gtex_v6> {
+      ?idt_ensg a ?type_gtex .
+    }
+  }
+  OPTIONAL {
+    GRAPH <http://rdf.integbio.jp/dataset/togosite/hpa_cell_specificity> {
+      ?idt_ensg a ?type_hpa_cell .
+    }
+  }
+  OPTIONAL {
+    GRAPH <http://rdf.integbio.jp/dataset/togosite/hpa_tissue_specificity> {
+      ?idt_ensg a ?type_hpa_tissue .
+    }
+  }
+
+  OPTIONAL {
+    GRAPH <http://rdf.integbio.jp/dataset/togosite/refex_tissue_specific_genes_gtex_v6> {
+      ?idt_ensg refexo:isPositivelySpecificTo ?gtex_tissue .
+    }
+    GRAPH <http://rdf.integbio.jp/dataset/togosite/refexsample_gtex_v8_summary> {
+      VALUES ?name {"cell type" "tissue"}
+      ?refexs schema:additionalProperty [
+        schema:name ?name ;
+        schema:value ?gtex_tissue_label ;
+        schema:valueReference ?gtex_tissue
+      ] .
+    }
+  }
+  OPTIONAL {
+    GRAPH <http://rdf.integbio.jp/dataset/togosite/hpa_cell_specificity> {
+      ?idt_ensg refexo:isPositivelySpecificTo ?hpa_cell .
+    }
+    GRAPH <http://rdf.integbio.jp/dataset/togosite/caloha> {
+      ?hpa_cell rdfs:label ?hpa_cell_label .
+    }
+  }
+  OPTIONAL {
+    GRAPH <http://rdf.integbio.jp/dataset/togosite/hpa_tissue_specificity> {
+      ?idt_ensg refexo:isPositivelySpecificTo ?hpa_tissue .
+    }
+    GRAPH <http://rdf.integbio.jp/dataset/togosite/caloha> {
+      ?hpa_tissue rdfs:label ?hpa_tissue_label .
+    }
+  }
+}
+```
+
+## `return`
+
+```javascript
+({ main, id }) => {
+  let data = main.results.bindings[0];
+  let ts_gtex = data.gtex_tissue_labels.value;
+  if (ts_gtex == "") {
+    if (data.type_gtex?.value)
+      ts_gtex = "(Low tissue specificity)";
+    else 
+      ts_gtex = "N/A";
+  } else {
+    ts_gtex = "<ul><li>" + ts_gtex.split(", ").join("</li><li>") + "</li></ul>";
+  }
+  let ts_hpa = data.hpa_tissue_labels.value;
+  if (ts_hpa == "") {
+    if (data.type_hpa_tissue?.value)
+      ts_hpa = "(Low tissue specificity)";
+    else 
+      ts_hpa = "N/A";
+  } else {
+    ts_hpa = "<ul><li>" + ts_hpa.split(", ").join("</li><li>") + "</li></ul>";
+  }
+  let cs_hpa = data.hpa_cell_labels.value;
+  if (cs_hpa == "") {
+    if (data.type_hpa_cell?.value)
+      cs_hpa = "(Low cell specificity)";
+    else 
+      cs_hpa = "N/A";
+  } else {
+    cs_hpa = "<ul><li>" + cs_hpa.split(", ").join("</li><li>") + "</li></ul>";
+  }
+
+  let objs = [{
+    "Ensembl ID": data.ensg_id.value,
+    "Ensembl URL": data.idt_ensg.value,
+    "Gene symbol": data.gene_symbol.value,
+    "Description": data.desc.value,
+    "Gene type": data.type_label.value,
+    "Location": data.location.value,
+    "Tissue specificity (GTEx)": ts_gtex,
+    "Tissue specificity (HPA)": ts_hpa,
+    "Cell specificity (HPA)": cs_hpa,
+    "Expression": "<a href=\"https://gtexportal.org/home/gene/" + id + "\">" + "View Expression at GTEx Portal</a>, " +
+                  "<a href=\"https://www.proteinatlas.org/" + id + "\">" + "View Expression at ProteinAtlas</a>"
+  }];
+
+  return objs;
+};
+```

--- a/repository/metastanza_glytoucan.md
+++ b/repository/metastanza_glytoucan.md
@@ -1,0 +1,57 @@
+# Glycan information from GlyCosmos RDF （池田）
+
+## Endpoint
+
+https://ts.glycosmos.org/sparql
+
+## Parameters
+* `id`
+  * default: G14606UO
+  * example: G14606UO
+
+## `main`
+
+```sparql
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX glycan: <http://purl.jp/bio/12/glyco/glycan#>
+PREFIX mass: <https://glycoinfo.gitlab.io/wurcsframework/org/glycoinfo/wurcsframework/1.0.1/wurcsframework-1.0.1.jar#>
+PREFIX struct: <https://glytoucan.org/Structures/Glycans/>
+PREFIX glycan2: <http://rdf.glycoinfo.org/glycan/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+SELECT DISTINCT ?gtc_1 ?mass ?sbsmpt ?wurcs_label ?iupac (GROUP_CONCAT(DISTINCT ?tissue_label; separator=", ") AS ?tissue_labels)
+WHERE {
+  VALUES ?gtc_1 { struct:{{id}} }
+  VALUES ?gtc_2 { glycan2:{{id}} }
+  ?wurcs mass:WURCSMassCalculator ?mass ;
+         rdfs:seeAlso ?gtc_1 ;
+         rdfs:label ?wurcs_label ;
+         a ?sbsmpt .
+  OPTIONAL {
+  [] glycan:has_glycan ?gtc_2 ;
+     a <http://purl.jp/bio/4/id/200906013374193296> ;
+     glycan:has_tissue ?tissue .
+  ?tissue rdfs:label ?tissue_label .
+  }
+  OPTIONAL {
+    ?wurcs rdfs:label / ^glycan:has_sequence / ^glycan:has_glycosequence / skos:altLabel ?iupac .
+  }
+}GROUP BY ?gtc_1 ?mass ?sbsmpt ?wurcs_label ?iupac
+```
+
+## `return`
+
+```javascript
+({ main, id }) => {
+  return main.results.bindings.map((elem) => ({
+    ID: id,
+    url: "https://glycosmos.org/glycans/show?gtc_id=" + id,
+    IUPAC: elem.iupac?.value ?? "",
+    WURCS: elem.wurcs_label.value,
+    mass: elem.mass.value,
+    subsumption: elem.sbsmpt.value.replace("http://www.glycoinfo.org/glyco/owl/relation#", "").replace(/_/g, " "),
+    tissue: elem.tissue_labels?.value ?? "",
+    image: "<img src=\"https://image.beta.glycosmos.org/snfg/png/" + id + "\" width=\"50%\ height=\"50%\" />"
+  }))
+}
+```

--- a/repository/metastanza_hp.md
+++ b/repository/metastanza_hp.md
@@ -1,0 +1,86 @@
+# Disease detail for metastanza template (ikeda)
+
+## Endpoint
+
+https://integbio.jp/togosite/sparql
+
+## Parameters
+
+* `id`
+  * default: 0030432
+  * example: 0030432
+
+## `main`
+
+```sparql
+PREFIX go: <http://www.geneontology.org/formats/oboInOwl#>
+PREFIX hp: <http://identifiers.org/HP/>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?hpo ?id ?label ?definition
+       (GROUP_CONCAT(DISTINCT ?dbxref, "__") AS ?dbxrefs)
+       ?comment
+       (GROUP_CONCAT(DISTINCT ?parent_id, "__") AS ?parent_ids)
+       (GROUP_CONCAT(DISTINCT ?parent_label, "__") AS ?parent_labels)
+       (GROUP_CONCAT(DISTINCT ?exact_synonym, "__")AS ?exact_synonyms)
+       (GROUP_CONCAT(DISTINCT ?related_synonym, "__") AS ?related_synonyms)
+WHERE {
+  VALUES ?hpo { <http://purl.obolibrary.org/obo/HP_{{id}}> }
+  GRAPH <http://rdf.integbio.jp/dataset/togosite/hpo> {
+    ?hpo rdfs:label ?label .
+    OPTIONAL { ?hpo obo:IAO_0000115 ?definition . }
+    OPTIONAL { ?hpo go:hasDbXref ?dbxref . }
+    OPTIONAL { ?hpo rdfs:comment ?comment . }
+    OPTIONAL { ?hpo go:hasExactSynonym ?exact_synonym . }
+    OPTIONAL { ?hpo go:hasRelatedSynonym ?related_synonym . }
+    OPTIONAL { 
+      ?hpo rdfs:subClassOf ?parent .
+      ?parent rdfs:label ?parent_label .
+      BIND(REPLACE(STR(?parent), 'http://purl.obolibrary.org/obo/HP_', 'HP:') AS ?parent_id)
+    }
+    BIND(REPLACE(STR(?hpo), 'http://purl.obolibrary.org/obo/HP_', 'HP:') AS ?id)
+  }
+}
+```
+
+## `return`
+
+```javascript
+({ main }) => {
+  const objs = [];
+  const data = main.results.bindings[0];
+  objs[0] = {
+    "URL": data.hpo.value,
+    "ID": data.id.value,
+    "label": data.label.value,
+    "definition": data.definition?.value ?? "",
+    "comment": data.comment?.value ?? "",
+    "xref": "",
+    "subclass_of": "",
+    "exact_synonym": "",
+    "related_synonym": ""
+  };
+  const prefix = "http://purl.obolibrary.org/obo/";
+  if (data.parent_ids?.value) {
+    const ids = data.parent_ids.value.split("__");
+    const labels = data.parent_labels.value.split("__");
+    objs[0]["subclass_of"] = makePairList(ids, labels, ids.map((id)=>prefix+id.replace(":", "_")));
+  }
+  if (data.exact_synonyms?.value) objs[0].exact_synonym = makeList(data.exact_synonyms.value.split("__"));
+  if (data.related_synonyms?.value) objs[0].related_synonym = makeList(data.related_synonyms.value.split("__"));
+  if (data.dbxrefs?.value) objs[0].xref = makeList(data.dbxrefs.value.split("__"));
+  return objs;
+
+  function makeLink(url, text) {
+    return "<a href=\"" + url + "\" target=\"_blank\">" + text + "</a>";
+  }
+  function makeList(strs) {
+    return "<ul><li>" + strs.join("</li><li>") + "</li></ul>";
+  }
+  function makePairList(ids, labels, urls) {
+    return makeList(ids.map((id, i)=>makeLink(urls[i], id) + " " + labels[i]));
+  }
+};
+```

--- a/repository/metastanza_mesh.md
+++ b/repository/metastanza_mesh.md
@@ -1,0 +1,92 @@
+# Disease detail for metastanza template (ikeda)
+
+## Endpoint
+
+https://integbio.jp/togosite/sparql
+
+## Parameters
+
+* `id`
+  * default: D002804
+  * example: D008947
+
+## `main`
+
+```sparql
+PREFIX mesh: <http://id.nlm.nih.gov/mesh/>
+PREFIX meshv: <http://id.nlm.nih.gov/mesh/vocab#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT DISTINCT ?mesh ?id ?label ?preferred_concept_id ?preferred_concept_label
+                (GROUP_CONCAT(DISTINCT ?concept_id, "__") AS ?concept_ids)
+                (GROUP_CONCAT(DISTINCT ?concept_label, "__") AS ?concept_labels)
+                (GROUP_CONCAT(DISTINCT ?broader_id, "__") AS ?broader_ids)
+                (GROUP_CONCAT(DISTINCT ?broader_label, "__") AS ?broader_labels)
+                ?note
+FROM <http://rdf.integbio.jp/dataset/togosite/mesh>
+WHERE {
+  VALUES ?mesh { mesh:{{id}} }
+  ?mesh meshv:identifier ?id ;
+        rdfs:label ?label .
+  ?mesh meshv:preferredConcept ?preferred_concept .
+  ?preferred_concept meshv:identifier ?preferred_concept_id ;
+                          rdfs:label ?preferred_concept_label .
+  OPTIONAL {
+    ?preferred_concept meshv:scopeNote ?note .
+  }
+  OPTIONAL {
+    ?mesh meshv:broaderDescriptor ?broader .
+    ?broader meshv:identifier ?broader_id ;
+                 rdfs:label ?broader_label .
+  }
+  OPTIONAL {
+    ?mesh meshv:scopeNote ?note .
+  }
+  OPTIONAL {
+    ?mesh meshv:concept ?concept .
+    ?concept meshv:identifier ?concept_id ;
+                  rdfs:label ?concept_label .
+  }
+}
+```
+
+## `return`
+
+```javascript
+({ main }) => {
+  const objs = [];
+  const data = main.results.bindings[0];
+  objs[0] = {
+    "ID": data.id.value,
+    "URL": data.mesh.value,
+    "label": data.label.value,
+    "concept": "",
+    "scope_note": data.note?.value ?? "",
+    "broader_descriptor": ""
+  };
+  const prefix = "http://id.nlm.nih.gov/mesh/";
+  if (data.broader_ids?.value) {
+    const ids = data.broader_ids.value.split("__");
+    const labels = data.broader_labels.value.split("__");
+    objs[0].broader_descriptor = makePairList(ids, labels, prefix);
+  }
+  if (data.concept_ids?.value) {
+    const ids = data.concept_ids.value.split("__");
+    const labels = data.concept_labels.value.split("__");
+    objs[0].concept = makePairList(ids, labels, ids.map((id)=>prefix+id));
+  }
+  objs[0].preferred_concept = makeLink(prefix + data.preferred_concept_id.value, data.preferred_concept_id.value)
+                              + " " + data.preferred_concept_label.value;
+  return objs;
+
+  function makeLink(url, text) {
+    return "<a href=\"" + url + "\" target=\"_blank\">" + text + "</a>";
+  }
+  function makeList(strs) {
+    return "<ul><li>" + strs.join("</li><li>") + "</li></ul>";
+  }
+  function makePairList(ids, labels, urls) {
+    return makeList(ids.map((id, i)=>makeLink(urls[i], id) + " " + labels[i]));
+  }
+};
+```

--- a/repository/metastanza_mondo.md
+++ b/repository/metastanza_mondo.md
@@ -1,0 +1,80 @@
+# Disease detail for metastanza template (ikeda)
+
+## Endpoint
+
+https://integbio.jp/togosite/sparql
+
+## Parameters
+
+* `id`
+  * default: 0004997
+  * example: 0004997, 0005854
+
+## `main`
+
+```sparql
+PREFIX mondo: <http://purl.obolibrary.org/obo/MONDO_>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX oboinowl: <http://www.geneontology.org/formats/oboInOwl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT DISTINCT ?mondo ?id ?label ?definition
+                (GROUP_CONCAT(DISTINCT ?xref, "__") AS ?xrefs)
+                (GROUP_CONCAT(DISTINCT ?synonym, "__") AS ?synonyms)
+                (GROUP_CONCAT(DISTINCT ?parent_id, "__")  AS ?parent_ids)
+                (GROUP_CONCAT(DISTINCT ?parent_label , "__") AS ?parent_labels)
+WHERE {
+  VALUES ?mondo { <http://purl.obolibrary.org/obo/MONDO_{{id}}> }
+  GRAPH <http://rdf.integbio.jp/dataset/togosite/mondo> {
+    ?mondo oboinowl:id ?id ;
+           rdfs:label ?label .
+    OPTIONAL { ?mondo obo:IAO_0000115 ?definition . }
+    OPTIONAL { ?mondo oboinowl:hasDbXref ?xref . }
+    OPTIONAL { ?mondo oboinowl:hasExactSynonym ?synonym . }
+    OPTIONAL {
+      ?mondo rdfs:subClassOf ?parent_class .
+      ?parent_class rdfs:label ?parent_label ;
+                    oboinowl:id ?parent_id .
+    }
+  }
+}
+```
+
+## `return`
+
+```javascript
+({ main, columns }) => {
+  const objs = [];
+  const data = main.results.bindings[0];
+  objs[0] = {
+    "URL": data.mondo.value,
+    "ID": data.id.value,
+    "label": data.label.value,
+    "definition": data.definition?.value ?? "",
+    "xref": "",
+    "subclass_of": "",
+    "synonym": ""
+  };
+  const prefix = "http://purl.obolibrary.org/obo/";
+  if (data.parent_ids?.value) {
+    const ids = data.parent_ids.value.split("__");
+    const labels = data.parent_labels.value.split("__");
+    objs[0]["subclass_of"] = makePairList(ids, labels, ids.map((id)=>prefix+id.replace(":", "_")));
+  }
+  if (data.synonyms?.value) objs[0].synonym = makeList(data.synonyms.value.split("__"));
+  if (data.xrefs?.value) objs[0].xref = makeList(data.xrefs.value.split("__"));
+  return objs;
+
+  function makeLink(url, text) {
+    return "<a href=\"" + url + "\" target=\"_blank\">" + text + "</a>";
+  }
+  function makeList(strs) {
+    return "<ul><li>" + strs.join("</li><li>") + "</li></ul>";
+  }
+  function makePairList(ids, labels, urls) {
+    return makeList(ids.map((id, i)=>makeLink(urls[i], id) + " " + labels[i]));
+  }
+};
+```

--- a/repository/metastanza_nando.md
+++ b/repository/metastanza_nando.md
@@ -1,0 +1,92 @@
+# Disease detail for metastanza template (ikeda)
+
+## Endpoint
+
+https://integbio.jp/togosite/sparql
+
+## Parameters
+
+* `id`
+  * default: 2200051
+  * example: 1200278
+
+## `main`
+
+```sparql
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX mondo: <http://purl.obolibrary.org/obo/MONDO_>
+PREFIX nando: <http://nanbyodata.jp/ontology/NANDO_>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX oboinowl: <http://www.geneontology.org/formats/oboInOwl#>
+
+SELECT DISTINCT ?nando ?id ?label ?label_jp ?description ?source
+                (GROUP_CONCAT(DISTINCT ?altLabel, "__") AS ?altLabels) ?parent_label ?parent_id
+                (GROUP_CONCAT(DISTINCT ?mondo_id, "__") AS ?mondo_ids)
+                (GROUP_CONCAT(DISTINCT ?mondo_label, "__") AS ?mondo_labels)
+FROM <http://rdf.integbio.jp/dataset/togosite/nando>
+FROM <http://rdf.integbio.jp/dataset/togosite/mondo>
+WHERE {
+  VALUES ?nando { <http://nanbyodata.jp/ontology/NANDO_{{id}}> }
+  ?nando dcterms:identifier ?id ;
+         rdfs:label ?label .
+  FILTER(lang(?label) = "en")
+  ?nando rdfs:label ?label_jp .
+  FILTER(lang(?label_jp) = "ja")
+  OPTIONAL { ?nando dcterms:description ?description . }
+  OPTIONAL { ?nando dcterms:source ?source . }
+  OPTIONAL { ?nando skos:altLabel ?altLabel . }
+  OPTIONAL {
+    ?nando skos:closeMatch ?mondo . 
+    ?mondo oboinowl:id ?mondo_id ;
+           rdfs:label ?mondo_label .
+  }
+  OPTIONAL {
+    ?nando rdfs:subClassOf ?parent .
+    ?parent rdfs:label ?parent_label ;
+            dcterms:identifier ?parent_id .
+    FILTER(lang(?parent_label) = "en")
+  }
+}
+```
+
+## `return`
+
+```javascript
+({ main, columns }) => {
+ const objs = [];
+  const data = main.results.bindings[0];
+  objs[0] = {
+    "URL": data.nando.value,
+    "ID": data.id.value,
+    "label": data.label.value,
+    "label_ja": data.label_jp.value,
+    "description": data.description?.value ?? "",
+    "source": data.source?.value ?? "",
+    "altLabel": "",
+    "MONDO_related": "",
+    "subclass_of": ""
+  };
+  const prefix = "http://nanbyodata.jp/ontology/";
+  if (data.parent_id?.value)
+    objs[0]["subclass_of"] = makeLink(prefix+data.parent_id.value.replace(":", "_"),
+                                      data.parent_id.value) + " " + data.parent_label.value;
+  if (data.altLabels?.value) objs[0]["altLabel"] = makeList(data.altLabels.value.split("__"));
+  if (data.mondo_ids?.value) {
+    const ids = data.mondo_ids.value.split("__");
+    const labels = data.mondo_labels.value.split("__");
+    objs[0]["MONDO_related"] = makePairList(ids, labels, ids.map((id)=>"http://purl.obolibrary.org/obo/"+id.replace(":", "_")));
+  }
+  return objs;
+
+  function makeLink(url, text) {
+    return "<a href=\"" + url + "\" target=\"_blank\">" + text + "</a>";
+  }
+  function makeList(strs) {
+    return "<ul><li>" + strs.join("</li><li>") + "</li></ul>";
+  }
+  function makePairList(ids, labels, urls) {
+    return makeList(ids.map((id, i)=>makeLink(urls[i], id) + " " + labels[i]));
+  }
+};
+```

--- a/repository/metastanza_ncbigene.md
+++ b/repository/metastanza_ncbigene.md
@@ -1,0 +1,111 @@
+## Endpoint
+
+https://integbio.jp/togosite/sparql
+
+## Parameters
+
+* `id`
+  * default: 1
+  * example: 1
+
+## `main`
+
+```sparql
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ncbigene: <http://identifiers.org/ncbigene/>
+PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX refexo: <http://purl.jp/bio/01/refexo#>
+PREFIX nuc: <http://ddbj.nig.ac.jp/ontologies/nucleotide/>
+PREFIX hop: <http://purl.org/net/orthordf/hOP/ontology#>
+
+SELECT ?ncbigene ?ncbigene_id ?desc ?location ?gene_symbol ?type_label
+       (GROUP_CONCAT(DISTINCT ?others; separator="__") AS ?other_names)
+       (GROUP_CONCAT(DISTINCT ?p_tissue_label; separator=", ") AS ?p_tissue_labels)
+       (GROUP_CONCAT(DISTINCT ?n_tissue_label; separator=", ") AS ?n_tissue_labels)
+       (GROUP_CONCAT(DISTINCT ?synonym; separator=", ") AS ?synonyms)
+WHERE {
+  VALUES ?ncbigene { ncbigene:{{id}} }
+  GRAPH <http://rdf.integbio.jp/dataset/togosite/homo_sapiens_gene_info> {
+    ?ncbigene dct:description ?desc ;
+              dct:identifier ?ncbigene_id ;
+              hop:typeOfGene ?type_label ;
+              nuc:chromosome ?chromosome ;
+              nuc:map ?location .
+    OPTIONAL {
+      ?ncbigene nuc:standard_name ?gene_symbol .
+    }
+    OPTIONAL {
+      ?ncbigene nuc:gene_synonym ?synonym .
+    }
+    OPTIONAL {
+      ?ncbigene dct:alternative ?others .
+    }
+  }
+  VALUES ?p { refexo:affyProbeset refexo:refseq }
+  VALUES ?graph { <http://rdf.integbio.jp/dataset/togosite/refex_tissue_specific_rnaseq_human_PRJEB2445>
+                  <http://rdf.integbio.jp/dataset/togosite/refex_tissue_specific_genechip_human_GSE7307> }
+  OPTIONAL {
+    GRAPH <http://rdf.integbio.jp/dataset/togosite/refex_id_relation_human> {
+      ?ncbigene ?p ?gene .
+    }
+    GRAPH ?graph {
+      ?gene refexo:isPositivelySpecificTo ?p_tissue .
+    }
+    GRAPH <http://rdf.integbio.jp/dataset/togosite/refexo> {
+      ?p_tissue rdfs:label ?p_tissue_label .
+      FILTER(lang(?p_tissue_label) = 'en')
+    }
+  }
+  OPTIONAL {
+    GRAPH <http://rdf.integbio.jp/dataset/togosite/refex_id_relation_human> {
+      ?ncbigene ?p ?gene .
+    }
+    GRAPH ?graph {
+      ?gene refexo:isNegativelySpecificTo ?n_tissue .
+    }
+    GRAPH <http://rdf.integbio.jp/dataset/togosite/refexo> {
+      ?n_tissue rdfs:label ?n_tissue_label .
+      FILTER(lang(?n_tissue_label) = 'en')
+    }
+  }
+}
+```
+
+## `return`
+
+```javascript
+({ main, id }) => {
+  let data = main.results.bindings[0];
+  let objs = [{
+    "NCBI_Gene_ID": data.ncbigene_id.value,
+    "NCBI_Gene_URL": data.ncbigene.value,
+    "Gene_symbol": data.gene_symbol.value,
+    "Synonym": data.synonyms.value,
+    "Description": data.desc.value,
+    "Gene_type": data.type_label.value,
+    "Location": data.location.value,
+    "Other_names": "",
+  }];
+
+  objs[0]["Tissue-specific_high_expression_(RefEx)"] = ""
+  if (data.p_tissue_labels?.value)
+    objs[0]["Tissue-specific_high_expression_(RefEx)"] += makeList(data.p_tissue_labels.value.split(", "));
+  objs[0]["Tissue-specific_low_expression_(RefEx)"] = ""
+  if (data.n_tissue_labels?.value)
+    objs[0]["Tissue-specific_low_expression_(RefEx)"] += makeList(data.n_tissue_labels.value.split(", "));
+
+  if (data.other_names?.value) objs[0].Other_names = makeList(data.other_names.value.split("__"));
+  return objs;
+
+  function makeLink(url, text) {
+    return "<a href=\"" + url + "\" target=\"_blank\">" + text + "</a>";
+  }
+  function makeList(strs) {
+    return "<ul><li>" + strs.join("</li><li>") + "</li></ul>";
+  }
+  function makePairList(ids, labels, urls) {
+    return makeList(ids.map((id, i)=>makeLink(urls[i], id) + " " + labels[i]));
+  }
+};
+```

--- a/repository/metastanza_pdb.md
+++ b/repository/metastanza_pdb.md
@@ -1,0 +1,86 @@
+# Gene attributes from PDB RDF（井手)
+
+## Endpoint
+
+https://integbio.jp/rdf/sparql
+
+## Parameters
+* `id`
+  * default: 6TIW
+  * example: 6TIW, 6W9K
+
+## `main`
+
+```sparql
+PREFIX pdbr: <https://rdf.wwpdb.org/pdb/>
+PREFIX pdbo: <https://rdf.wwpdb.org/schema/pdbx-v50.owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dc: <http://purl.org/dc/elements/1.1/>
+
+SELECT DISTINCT ?pdb ?id ?title ?method ?polypeptide_number ?pH ?keywords ?text ?species ?host
+                (GROUP_CONCAT(DISTINCT ?uniprot; separator="__") AS ?uniprots)
+                (GROUP_CONCAT(DISTINCT ?uniprot_desc; separator="__") AS ?uniprot_descs)
+WHERE {
+  VALUES ?pdb { pdbr:{{id}} }
+  ?pdb dc:title ?title ;
+       pdbo:has_exptlCategory/pdbo:has_exptl/pdbo:exptl.method ?method .  
+  OPTIONAL { ?pdb pdbo:has_exptl_crystal_growCategory/pdbo:has_exptl_crystal_grow/pdbo:exptl_crystal_grow.pH ?pH . }
+  OPTIONAL { ?pdb pdbo:has_em_bufferCategory/pdbo:has_em_buffer/pdbo:em_buffer.pH ?pH . }
+
+  ?pdb pdbo:has_struct_keywordsCategory/pdbo:has_struct_keywords/pdbo:struct_keywords.pdbx_keywords ?keywords .
+  ?pdb pdbo:has_struct_keywordsCategory/pdbo:has_struct_keywords/pdbo:struct_keywords.text ?text .
+  ?pdb pdbo:has_entity_src_genCategory/pdbo:has_entity_src_gen/pdbo:entity_src_gen.pdbx_gene_src_scientific_name ?species .
+  ?pdb pdbo:has_entity_src_genCategory/pdbo:has_entity_src_gen/pdbo:entity_src_gen.pdbx_host_org_scientific_name ?host .
+    
+  {
+    SELECT DISTINCT ?pdb COUNT(?polypeptide) AS ?polypeptide_number {
+     ?pdb pdbo:has_entity_polyCategory/pdbo:has_entity_poly ?polypeptide.
+     VALUES ?polypeptide_type { "polypeptide(L)" "polypeptide(D)"}
+     ?polypeptide pdbo:entity_poly.type ?polypeptide_type .
+     #?polypeptide rdfs:seeAlso ?uniprot_link . #DNAのentryを排除
+    }
+  }
+  OPTIONAL {
+    ?pdb pdbo:has_entityCategory/pdbo:has_entity ?entity_each .
+    ?entity_each pdbo:referenced_by_struct_ref/pdbo:link_to_uniprot ?uniprot .
+    ?entity_each pdbo:entity.pdbx_description ?uniprot_desc .
+  }
+  BIND(REPLACE(STR(?pdb), pdbr:, "") AS ?id)
+}
+```
+
+## `return`
+
+```javascript
+({ main }) => {
+  const data = main.results.bindings[0];
+  const objs = main.results.bindings.map((elem) => ({
+    id: elem.id.value,
+    url: elem.pdb.value,
+    title: elem.title.value,
+    method: elem.method.value,
+    polypeptide_number: elem.polypeptide_number.value,
+    pH: elem.pH?.value ?? "N/A",
+    classification: elem.keywords.value,
+    functional_keywords: elem.text.value,
+    species: elem.species.value,
+    "host_(expression_system)": elem.host.value
+  }));
+
+  if (data.uniprots?.value)
+    objs[0].uniprot = makePairList(data.uniprots.value.split("__").map((url)=>url.replace("http://purl.uniprot.org/uniprot/", "")),
+                                   data.uniprot_descs.value.split("__"),
+                                   data.uniprots.value.split("__"));
+  return objs;
+
+  function makeLink(url, text) {
+    return "<a href=\"" + url + "\" target=\"_blank\">" + text + "</a>";
+  }
+  function makeList(strs) {
+    return "<ul><li>" + strs.join("</li><li>") + "</li></ul>";
+  }
+  function makePairList(ids, labels, urls) {
+    return makeList(ids.map((id, i)=>makeLink(urls[i], id) + " " + labels[i]));
+  }
+};
+```

--- a/repository/metastanza_pubchem_compound.md
+++ b/repository/metastanza_pubchem_compound.md
@@ -1,0 +1,58 @@
+# 化合物の詳細情報を出す（信定・山本・建石）
+
+## Parameters
+
+* `id`
+  * default:　2244
+  * example: 2244, 34756
+
+## Endpoint
+
+https://integbio.jp/rdf/pubchem/sparql
+
+## `main`
+```sparql
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sio: <http://semanticscience.org/resource/>
+PREFIX compound: <http://rdf.ncbi.nlm.nih.gov/pubchem/compound/>
+PREFIX pubchemv: <http://rdf.ncbi.nlm.nih.gov/pubchem/vocabulary#>
+
+SELECT DISTINCT ?pubchem ?id ?molecular_formula ?label ?molecular_weight ?smiles ?inchi ?formula_img
+WHERE {
+  VALUES ?pubchem  { compound:CID{{id}} }
+    OPTIONAL { ?pubchem sio:has-attribute
+      [ a sio:CHEMINF_000382; sio:has-value ?label  ] }
+    OPTIONAL { ?pubchem sio:has-attribute
+      [ a sio:CHEMINF_000334; sio:has-value ?molecular_weight] }
+    OPTIONAL { ?pubchem sio:has-attribute
+      [ a sio:CHEMINF_000335; sio:has-value ?molecular_formula ] }
+    OPTIONAL { ?pubchem sio:has-attribute
+      [ a sio:CHEMINF_000376; sio:has-value ?smiles ] }
+    OPTIONAL { ?pubchem sio:has-attribute
+      [ a sio:CHEMINF_000396; sio:has-value ?inchi ] }
+    BIND (strafter(str(?pubchem), "http://rdf.ncbi.nlm.nih.gov/pubchem/compound/") AS ?id)
+    BIND(CONCAT("https://pubchem.ncbi.nlm.nih.gov/image/imagefly.cgi?cid=",(SUBSTR(STR(?id),4)),"&width=500&height=500") AS ?formula_img)
+}
+            
+```
+
+## `return`
+
+```javascript
+({ main }) => {
+  const objs = [];
+  const data = main.results.bindings[0];
+  objs[0] = {
+    URL: data.pubchem.value,
+    ID: data.id.value,
+    molecular_formula: data.molecular_formula?.value ?? "",
+    label: data.label?.value ?? "",
+    molecular_weight: data.molecular_weight?.value ?? "",
+    SMILES: data.smiles?.value ?? "",
+    InChI: data.inchi?.value ?? "",
+    formula_img: data.formula_img.value
+  };
+  return objs;
+};
+```

--- a/repository/metastanza_togovar.md
+++ b/repository/metastanza_togovar.md
@@ -1,0 +1,110 @@
+# Variant details and link to TogoVar  (三橋)
+
+## Description
+
+- Data sources
+    -  [TogoVar](https://togovar.biosciencedbc.jp/?) (limited to variants with frequency data in Japanese populations)
+- Query
+    - Input
+        - TogoVar id
+    - Output
+        -  TogoVar id
+        -  Variant type (SNV, Insersion, Deletion, InDel, Substitution) 
+        -  [HGVS notation](https://varnomen.hgvs.org/bg-material/simple/)
+        -  Link to TogoVar. See details about each variant in TogoVar.
+
+## Parameters
+
+* `tgv_id` TogoVar ID
+  * default: 
+  * example: tgv219804 (autosomal), tgv80912738(chr X), tgv67047924(chr Y), tgv67070461(MT)
+
+## Endpoint
+
+https://integbio.jp/togosite/sparql
+
+## `data`
+
+```sparql
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX obo_in_owl: <http://www.geneontology.org/formats/oboInOwl#>
+PREFIX faldo: <http://biohackathon.org/resource/faldo#>
+PREFIX m2r: <http://med2rdf.org/ontology/med2rdf#>
+PREFIX tgvo: <http://togovar.biosciencedbc.jp/vocabulary/>
+
+#SELECT DISTINCT ?tgv_id ?variation ?type_label ?reference ?ref ?alt ?hgvs ?link_to_togovar
+SELECT DISTINCT ?tgv_id ?type_label ?hgvs ?link_to_togovar
+FROM <http://rdf.integbio.jp/dataset/togosite/variation>
+FROM <http://rdf.integbio.jp/dataset/togosite/so>
+WHERE {
+    VALUES ?tgv_id { "{{tgv_id}}" }
+
+    ?variation dct:identifier ?tgv_id ;
+        rdfs:label ?label ;
+        faldo:location ?_loc ;
+        a ?_type .
+
+    ?_loc (faldo:end|faldo:after)?/faldo:reference ?reference .
+
+    OPTIONAL { ?variation m2r:reference_allele ?ref . }
+    OPTIONAL { ?variation m2r:alternative_allele ?alt . }
+
+    FILTER ( ?_type IN (obo:SO_0001483, obo:SO_0000667, obo:SO_0000159, obo:SO_1000032, obo:SO_1000002) ) .
+
+    OPTIONAL {
+      ?_type rdfs:label ?type_label ;
+        obo_in_owl:id ?_so_id .
+
+      BIND(REPLACE(STR(?_so_id), ":", "_") AS ?so)
+    }
+
+    OPTIONAL {
+       ?variation tgvo:hasConsequence/rdfs:label ?hgvs .
+       FILTER(!STRSTARTS(?hgvs, 'ENS'))
+    }
+  
+    BIND(IRI(CONCAT("https://togovar.biosciencedbc.jp/variant/", ?tgv_id)) AS ?link_to_togovar)
+}
+```
+
+## `results`
+```javascript
+
+({ data }) =>  {
+// See https://www.ncbi.nlm.nih.gov/assembly/GCF_000001405.13/
+var chr2nc = {};
+chr2nc[1]="NC_000001.10";
+chr2nc[2]="NC_000002.11";
+chr2nc[3]="NC_000003.11";
+chr2nc[4]="NC_000004.11";
+chr2nc[5]="NC_000005.9";
+chr2nc[6]="NC_000006.11";
+chr2nc[7]="NC_000007.13";
+chr2nc[8]="NC_000008.10";
+chr2nc[9]="NC_000009.11";
+chr2nc[10]="NC_000010.10";
+chr2nc[11]="NC_000011.9";
+chr2nc[12]="NC_000012.11";
+chr2nc[13]="NC_000013.10";
+chr2nc[14]= "NC_000014.8";
+chr2nc[15]="NC_000015.9";
+chr2nc[16]="NC_000016.9";
+chr2nc[17]="NC_000017.10";
+chr2nc[18]="NC_000018.9";
+chr2nc[19]="NC_000019.9";
+chr2nc[20]="NC_000020.10";
+chr2nc[21]="NC_000021.8";
+chr2nc[22]="NC_000022.10";
+chr2nc['X']="NC_000023.10";
+chr2nc['Y']="NC_000024.9";
+chr2nc['MT']=" NC_012920.1";   // https://www.ncbi.nlm.nih.gov/nucleotide/NC_012920.1
+  
+    return data.results.bindings.map((d) => ({
+      tgv_id: d.tgv_id .value,
+      type_label: d.type_label.value,
+      hgvs:  d.hgvs.value.replace(/^(\S+):([gm].+)/, function(m, chr, pos_allele){ return chr2nc[chr] + ":" + pos_allele; }),
+      link_to_togovar: d.link_to_togovar.value
+    }));
+ };
+```

--- a/repository/metastanza_uniprot.md
+++ b/repository/metastanza_uniprot.md
@@ -1,0 +1,202 @@
+# Protein attributes from Uniprot RDF（井手, 守屋, 池田）
+
+## Parameters
+* `uniprot`
+  * default: P06493
+  * example: P06493
+  
+## `uniprot_list`
+```javascript
+({ uniprot }) => {
+  uniprot = uniprot.replace(/\s/g, "");
+  if (uniprot) {
+    return uniprot.split(",");
+  } else {
+    return false;
+  }
+};
+```
+
+## Endpoint
+https://integbio.jp/togosite/sparql
+
+## `main`
+一つの SPARQL だと遅いので分割
+```sparql
+PREFIX uniprot: <http://purl.uniprot.org/uniprot/>
+PREFIX core: <http://purl.uniprot.org/core/>
+PREFIX db: <http://purl.uniprot.org/database/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT DISTINCT ?entry ?id ?mnemonic ?full_name ?short_name ?length ?mass 
+  (GROUP_CONCAT(distinct ?pdb ; separator = ",") AS ?pdbs)
+  (COUNT(DISTINCT ?citation) AS ?citation_number)
+FROM <http://rdf.integbio.jp/dataset/togosite/uniprot>
+WHERE{
+  {{#if uniprot_list}}
+  VALUES ?entry { {{#each uniprot_list}} uniprot:{{this}} {{/each}} }
+  {{/if}}
+  ?entry a core:Protein ;
+         core:mnemonic ?mnemonic ;
+         core:recommendedName|core:submittedName ?rname .
+  ?rname core:fullName ?full_name .
+  OPTIONAL{
+    ?rname core:shortName ?short_name .
+  }
+  ?entry core:sequence [
+    a core:Simple_Sequence ;
+    rdf:value ?sequence ;
+    core:mass ?mass
+    ] .
+  OPTIONAL{
+    ?entry core:citation ?citation .
+  }
+  OPTIONAL {
+    ?entry rdfs:seeAlso ?pdb .
+    ?pdb core:database db:PDB .
+  }
+  BIND(STRLEN(?sequence) AS ?length)
+  BIND(REPLACE(STR(?entry), uniprot:, "") AS ?id)
+}
+
+```
+
+## `go_bp`
+```sparql
+PREFIX uniprot: <http://purl.uniprot.org/uniprot/>
+PREFIX core: <http://purl.uniprot.org/core/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+SELECT DISTINCT ?entry
+  (GROUP_CONCAT(DISTINCT ?go_bp_l, ",") AS ?biological_process)
+FROM <http://rdf.integbio.jp/dataset/togosite/uniprot>
+FROM <http://rdf.integbio.jp/dataset/togosite/go>
+WHERE{
+  {{#if uniprot_list}}
+  VALUES ?entry { {{#each uniprot_list}} uniprot:{{this}} {{/each}} }
+  {{/if}}
+  OPTIONAL{
+    GRAPH <http://rdf.integbio.jp/dataset/togosite/uniprot> {
+      ?entry core:classifiedWith ?go_bp .
+    }
+    GRAPH <http://rdf.integbio.jp/dataset/togosite/go> {
+      ?go_bp rdfs:subClassOf* obo:GO_0008150 ;
+             rdfs:label ?go_bp_l .
+    }
+  }
+}
+
+```
+
+## `go_mf`
+```sparql
+PREFIX uniprot: <http://purl.uniprot.org/uniprot/>
+PREFIX core: <http://purl.uniprot.org/core/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+SELECT DISTINCT ?entry
+  (GROUP_CONCAT(DISTINCT ?go_mf_l, ",") AS ?molecular_function)
+FROM <http://rdf.integbio.jp/dataset/togosite/uniprot>
+FROM <http://rdf.integbio.jp/dataset/togosite/go>
+WHERE{
+  {{#if uniprot_list}}
+  VALUES ?entry { {{#each uniprot_list}} uniprot:{{this}} {{/each}} }
+  {{/if}}
+  OPTIONAL{
+    GRAPH <http://rdf.integbio.jp/dataset/togosite/uniprot> {
+      ?entry core:classifiedWith ?go_mf .
+    }
+    GRAPH <http://rdf.integbio.jp/dataset/togosite/go> {
+      ?go_mf rdfs:subClassOf* obo:GO_0003674 ;
+             rdfs:label ?go_mf_l .
+    }
+  }
+}
+```
+
+## `go_cc`
+```sparql
+PREFIX uniprot: <http://purl.uniprot.org/uniprot/>
+PREFIX core: <http://purl.uniprot.org/core/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+SELECT DISTINCT ?entry
+  (GROUP_CONCAT(DISTINCT ?go_cc_l, ",") AS ?cellular_component)
+FROM <http://rdf.integbio.jp/dataset/togosite/uniprot>
+FROM <http://rdf.integbio.jp/dataset/togosite/go>
+WHERE{
+  {{#if uniprot_list}}
+  VALUES ?entry { {{#each uniprot_list}} uniprot:{{this}} {{/each}} }
+  {{/if}}
+  OPTIONAL{
+    GRAPH <http://rdf.integbio.jp/dataset/togosite/uniprot> {
+      ?entry core:classifiedWith ?go_cc .
+    }
+    GRAPH <http://rdf.integbio.jp/dataset/togosite/go> {
+      ?go_cc rdfs:subClassOf* obo:GO_0005575 ;
+             rdfs:label ?go_cc_l .
+    }
+  }
+}
+
+```
+
+## `tissue`
+```sparql
+PREFIX uniprot: <http://purl.uniprot.org/uniprot/>
+PREFIX core: <http://purl.uniprot.org/core/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+SELECT DISTINCT ?entry
+  (GROUP_CONCAT(DISTINCT ?tissue, ",") AS ?isolated_tissue) 
+FROM <http://rdf.integbio.jp/dataset/togosite/uniprot/tissues>
+FROM <http://rdf.integbio.jp/dataset/togosite/uniprot>
+WHERE{
+  {{#if uniprot_list}}
+  VALUES ?entry { {{#each uniprot_list}} uniprot:{{this}} {{/each}} }
+  {{/if}}
+  OPTIONAL {
+    ?entry core:isolatedFrom/skos:prefLabel ?tissue .
+  }
+}
+
+```
+
+## `return`
+
+```javascript
+({ main, go_bp, go_mf, go_cc, tissue }) => {
+  let obj = main.results.bindings.map(data => {
+    return Object.keys(data).reduce((obj, key) => {
+      obj[key] = data[key].value;
+      return obj;
+    }, {});
+  });
+  if (obj[0]["short_name"]) obj[0]["full_name"]  += " (" + obj[0]["short_name"] + ")";
+  if (obj[0]["length"]) obj[0]["length"] = obj[0]["length"].replace(/(\d)(?=(\d{3})+$)/g , '$1,');
+  if (obj[0]["mass"]) obj[0]["mass"] = obj[0]["mass"].replace(/(\d)(?=(\d{3})+$)/g , '$1,');
+  if (obj[0]["citation_number"]) obj[0]["citation_number"] = obj[0]["citation_number"].replace(/(\d)(?=(\d{3})+$)/g , '$1,');
+  if (obj[0]["pdbs"]) obj[0]["pdbs"] = obj[0]["pdbs"].split(/,/).map(d => {
+    return "<a href='" + d + "'>" + d.replace("http://rdf.wwpdb.org/pdb/", "") + "</a>";
+  }).join(", ");
+  obj[0]["biological_process"] = "";
+  obj[0]["molecular_function"] = "";
+  obj[0]["cellular_component"] = "";
+  obj[0]["isolated_tissue"] = "";
+  if (go_bp.results.bindings[0].biological_process.value)
+    obj[0]["biological_process"] = makeList(go_bp.results.bindings[0].biological_process.value.split(/,/));
+  if (go_mf.results.bindings[0].molecular_function.value)
+    obj[0]["molecular_function"] = makeList(go_mf.results.bindings[0].molecular_function.value.split(/,/));
+  if (go_cc.results.bindings[0].cellular_component.value)
+    obj[0]["cellular_component"] = makeList(go_cc.results.bindings[0].cellular_component.value.split(/,/));
+  if (tissue.results.bindings[0].isolated_tissue.value)
+    obj[0]["isolated_tissue"] = makeList(tissue.results.bindings[0].isolated_tissue.value.split(/,/));
+  return obj;
+  
+  function makeList(strs) {
+    return "<ul><li>" + strs.join("</li><li>") + "</li></ul>";
+  }
+};
+```


### PR DESCRIPTION
- template が参照する SPARQList の名称を `metastanza_{dataset}` に変更した
- カテゴリーごとにまとめられていた SPARQList はデータセットごとに分割した
- 本家へのクリッカブルリンクを付けた
- リストにしたほうが見やすいところはリストにした
- Compound 系に関して、構造の画像を出すという案があったが、直リンクになってしまうのでとりあえず廃止
- 一部項目名の変更やバグ修正